### PR TITLE
Fix server.rb - error when using iso package: due to setup.exe being checksummed against the iso's checksum

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -89,7 +89,7 @@ end
 
 windows_package package_name do
   source !is_iso ? package_url : "#{iso_extraction_dir}/#{node['sql_server']['server']['setup']}"
-  checksum package_checksum
+  checksum !is_iso ? package_checksum : nil
   timeout node['sql_server']['server']['installer_timeout']
   installer_type :custom
   options "/q /ConfigurationFile=#{config_file_path}"


### PR DESCRIPTION
For some reason this only started occurring when ran on bare metal box (was fine with Vagrant), but it's possible that it was due to different chef version (e.g. differences in implementing windows_package)

Full error was:
FATAL: Chef::Exceptions::ChecksumMismatch: windows_package[Microsoft SQL Server 2012 (64-bit)](sql_server::server line 90) had an error: Chef::Exceptions::ChecksumMismatch: Checksum on resource (b3aa8baf2a...) does not match checksum on content (308f6d9446....)
